### PR TITLE
Implementar franquicias de boleto (MedioBoleto, FranquiciaCompleta y BoletoGratuito)

### DIFF
--- a/TrabajoTarjeta/BoletoGratuito.cs
+++ b/TrabajoTarjeta/BoletoGratuito.cs
@@ -1,12 +1,28 @@
 ﻿namespace TrabajoTarjeta
 {
+    /// <summary>
+    /// Tarjeta de boleto gratuito estudiantil.
+    /// Permite a estudiantes viajar sin costo alguno.
+    /// Similar a la franquicia completa, no consume saldo al utilizarse.
+    /// </summary>
     public class BoletoGratuito : Tarjeta
     {
+        /// <summary>
+        /// Calcula la tarifa para boleto gratuito estudiantil.
+        /// </summary>
+        /// <param name="tarifaBase">Tarifa completa del boleto ($1580).</param>
+        /// <returns>Siempre devuelve $0 (viaje gratuito para estudiantes).</returns>
         public override decimal CalcularTarifa(decimal tarifaBase)
         {
             return 0;
         }
 
+        /// <summary>
+        /// Verifica si puede descontar el monto del saldo.
+        /// Como el boleto es gratuito (tarifa = $0), siempre puede viajar.
+        /// </summary>
+        /// <param name="monto">Monto que se desea descontar (será $0).</param>
+        /// <returns>Siempre devuelve true, permitiendo viajar sin saldo disponible.</returns>
         public override bool PuedeDescontar(decimal monto)
         {
             // Siempre puede descontar porque la tarifa es 0

--- a/TrabajoTarjeta/FranquiciaCompleta.cs
+++ b/TrabajoTarjeta/FranquiciaCompleta.cs
@@ -1,12 +1,28 @@
 ﻿namespace TrabajoTarjeta
 {
+    /// <summary>
+    /// Tarjeta con franquicia completa (jubilados/pensionados).
+    /// Permite viajar de forma gratuita sin consumir saldo.
+    /// No requiere saldo disponible para poder utilizarse.
+    /// </summary>
     public class FranquiciaCompleta : Tarjeta
     {
+        /// <summary>
+        /// Calcula la tarifa para franquicia completa.
+        /// </summary>
+        /// <param name="tarifaBase">Tarifa completa del boleto ($1580).</param>
+        /// <returns>Siempre devuelve $0 (viaje gratuito).</returns>
         public override decimal CalcularTarifa(decimal tarifaBase)
         {
             return 0;
         }
 
+        /// <summary>
+        /// Verifica si puede descontar el monto del saldo.
+        /// Como la franquicia completa viaja gratis (tarifa = $0), siempre puede pagar.
+        /// </summary>
+        /// <param name="monto">Monto que se desea descontar (será $0).</param>
+        /// <returns>Siempre devuelve true, permitiendo viajar sin restricciones de saldo.</returns>
         public override bool PuedeDescontar(decimal monto)
         {
             // Franquicia completa siempre puede pagar (tarifa = 0)

--- a/TrabajoTarjeta/MedioBoleto.cs
+++ b/TrabajoTarjeta/MedioBoleto.cs
@@ -1,7 +1,17 @@
 ﻿namespace TrabajoTarjeta
 {
+    /// <summary>
+    /// Tarjeta con beneficio de medio boleto estudiantil.
+    /// Paga el 50% del valor del pasaje (tarifa reducida a $790).
+    /// El descuento se aplica independientemente del día de la semana.
+    /// </summary>
     public class MedioBoleto : Tarjeta
     {
+        /// <summary>
+        /// Calcula la tarifa aplicando el descuento de medio boleto.
+        /// </summary>
+        /// <param name="tarifaBase">Tarifa completa del boleto ($1580).</param>
+        /// <returns>La mitad de la tarifa base ($790).</returns>
         public override decimal CalcularTarifa(decimal tarifaBase)
         {
             return tarifaBase / 2;


### PR DESCRIPTION
Closes #3

## Cambios realizados
- ✅ Documentada clase **MedioBoleto**: Paga el 50% de la tarifa ($790)
- ✅ Documentada clase **FranquiciaCompleta**: Viaje gratuito para jubilados/pensionados
- ✅ Documentada clase **BoletoGratuito**: Viaje gratuito para estudiantes
- ✅ Agregados comentarios XML a todos los métodos sobrescritos
- ✅ Explicado el comportamiento de `CalcularTarifa()` en cada clase
- ✅ Explicado el comportamiento de `PuedeDescontar()` para franquicias gratuitas

## Tipos de franquicias implementadas

### 1. MedioBoleto (Medio Boleto Estudiantil)
- Paga **$790** (50% de $1580)
- Descuento aplicado independientemente del día de la semana
- Hereda de `Tarjeta` y sobrescribe `CalcularTarifa()`

### 2. FranquiciaCompleta (Jubilados/Pensionados)
- Viaja **gratis** (tarifa = $0)
- `PuedeDescontar()` siempre retorna `true`
- No requiere saldo disponible para viajar

### 3. BoletoGratuito (Boleto Gratuito Estudiantil)
- Viaja **gratis** (tarifa = $0)
- Similar a FranquiciaCompleta pero para estudiantes
- `PuedeDescontar()` siempre retorna `true`

## Herencia
Todas las clases heredan de `Tarjeta` y sobrescriben métodos según las necesidades:
- `CalcularTarifa()`: Define cuánto paga cada tipo de tarjeta
- `PuedeDescontar()`: Define si puede realizar el viaje (siempre `true` para gratuitas)

## Tests existentes
Los tests validan:
- ✅ FranquiciaCompleta siempre puede pagar un boleto
- ✅ El monto del boleto con MedioBoleto es la mitad del normal

## Archivos modificados
- `MedioBoleto.cs`
- `FranquiciaCompleta.cs`
- `BoletoGratuito.cs`